### PR TITLE
Return action from dispatch function

### DIFF
--- a/__tests__/atomWithStore.test.tsx
+++ b/__tests__/atomWithStore.test.tsx
@@ -16,13 +16,20 @@ it('count state', async () => {
   const storeAtom = atomWithStore(store)
   store.dispatch({ type: 'INC' })
 
+  let dispatched
+
   const Counter = () => {
     const [state, dispatch] = useAtom(storeAtom)
 
     return (
       <>
         count: {state.count}
-        <button onClick={() => dispatch({ type: 'INC' })}>button</button>
+        <button
+          onClick={() => {
+            dispatched = dispatch({ type: 'INC' })
+          }}>
+          button
+        </button>
       </>
     )
   }
@@ -38,6 +45,7 @@ it('count state', async () => {
   fireEvent.click(getByText('button'))
   await findByText('count: 2')
   expect(store.getState().count).toBe(2)
+  expect(dispatched).toEqual({ type: 'INC' })
 
   act(() => {
     store.dispatch({ type: 'INC' })

--- a/src/atomWithStore.ts
+++ b/src/atomWithStore.ts
@@ -16,7 +16,7 @@ export function atomWithStore<State, A extends Action = AnyAction>(
   const derivedAtom = atom(
     (get) => get(baseAtom),
     (_get, _set, action: A) => {
-      store.dispatch(action)
+      return store.dispatch(action)
     }
   )
   return derivedAtom

--- a/src/atomWithStore.ts
+++ b/src/atomWithStore.ts
@@ -15,9 +15,7 @@ export function atomWithStore<State, A extends Action = AnyAction>(
   }
   const derivedAtom = atom(
     (get) => get(baseAtom),
-    (_get, _set, action: A) => {
-      return store.dispatch(action)
-    }
+    (_get, _set, action: A) => store.dispatch(action)
   )
   return derivedAtom
 }


### PR DESCRIPTION
Fixed to return action value from the `dispatch()` as in the original `store.dispatch()`.

The return value especially important if you are using Redux Thunk.
